### PR TITLE
perf: 트랜젝션 실행 시간 측정(by AOP) 및 pord 구조화 로그 포맷 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 	implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+	implementation("net.logstash.logback:logstash-logback-encoder:7.4")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-aop")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/restart.sh
+++ b/restart.sh
@@ -12,4 +12,4 @@ fi
 
 echo "Starting app...(후후후...)"
 cd $APP_DIR
-nohup java -jar $APP_NAME > logs_$(date +%Y%m%d_%H%M%S).out 2>&1 &
+nohup java -Dspring.profiles.active=prod -jar $APP_NAME > logs_$(date +%Y%m%d_%H%M%S).out 2>&1 &

--- a/src/main/kotlin/com/parkjunhyung/IryeokFitAi/global/aop/TransactionTimingAspect.kt
+++ b/src/main/kotlin/com/parkjunhyung/IryeokFitAi/global/aop/TransactionTimingAspect.kt
@@ -1,0 +1,32 @@
+package com.parkjunhyung.IryeokFitAi.global.aop
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+// @Transactional 메서드 실행 시간 측정용 로그
+@Aspect
+@Component
+//@Profile("loadtest")  // 실제 개발 서버 prod 레벨의 OpenAI 호출 TS 시간 측정 위해 비활성화
+class TransactionTimingAspect {
+    private val log = LoggerFactory.getLogger(TransactionTimingAspect::class.java)
+
+    @Around("@annotation(jakarta.transaction.Transactional)")
+    fun measure(joinPoint: ProceedingJoinPoint): Any? {
+        val start = System.nanoTime()
+        try {
+            return joinPoint.proceed()
+        } finally {
+            val elapsedMs = (System.nanoTime() - start) / 1_000_000 // (ns -> ms)
+            val signature = joinPoint.signature
+            val args = joinPoint.args.joinToString(", ")
+            log.info(
+                "[PERF-TS] {}.{}({}) - {}ms - thread={}",
+                signature.declaringType.simpleName, signature.name, args, elapsedMs, Thread.currentThread().name
+            )
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!-- prod: Filebeat가 파싱할 JSON 포맷 -->
+    <springProfile name="prod">
+        <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <includeMdcKeyName>traceId</includeMdcKeyName>
+            </encoder>
+        </appender>
+
+        <!-- Filebeat가 읽을 로그 파일 -->
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>/var/log/iryeokfit/application.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>/var/log/iryeokfit/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>7</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <includeMdcKeyName>traceId</includeMdcKeyName>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="STDOUT"/>
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+
+    <!-- 로컬/테스트: 가독성 있는 포맷 + traceId -->
+    <springProfile name="!prod">
+        <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level [%X{traceId}] %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="STDOUT"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
### 변경사항
- 서버에 동시 사용자 늘려가며 부하테스트 진행하려 하는데, 트랜젝션 단위로 시간 측정하여 어떤 트랜젝션이 느린지, 커넥션을 오래 붙잡는지 확인하고자 함. 
- 기존의 ELK 스택에 logstash 파이프라인 추가하여 진행
    - JSON 형태의 파일로 로그 남김 -> filebeat가 tail해서 넘기는 구조
